### PR TITLE
Fixing lint

### DIFF
--- a/firestore/src/City.php
+++ b/firestore/src/City.php
@@ -27,9 +27,21 @@ namespace Google\Cloud\Samples\Firestore;
 # [START firestore_data_custom_type_definition]
 class City
 {
+    public $name;
+    public $state;
+    public $country;
+    public $capital;
+    public $population;
+    public $regions;
 
-    public function __construct($name, $state, $country, $capital = false, $population = 0,
-        $regions = []) {
+    public function __construct(
+        $name,
+        $state,
+        $country,
+        $capital = false,
+        $population = 0,
+        $regions = []
+    ) {
         $this->name = $name;
         $this->state = $state;
         $this->country = $country;

--- a/firestore/src/data_get_as_custom_type.php
+++ b/firestore/src/data_get_as_custom_type.php
@@ -24,6 +24,7 @@
 namespace Google\Cloud\Samples\Firestore;
 
 use Google\Cloud\Firestore\FirestoreClient;
+
 include "City.php";
 
 /**


### PR DESCRIPTION
Validated the changes in local terminal like this:

```
➜  firestore git:(firestore_data_get_as_custom_type) ✗ ~/.config/composer/vendor/bin/php-cs-fixer fix .
Loaded config default.
Using cache file ".php-cs-fixer.cache".

Fixed all files in 0.004 seconds, 12.000 MB memory used
➜  firestore git:(firestore_data_get_as_custom_type) ✗ 
➜  firestore git:(firestore_data_get_as_custom_type) ✗
```

AND 

```
➜  firestore git:(firestore_data_get_as_custom_type) ✗ XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit -c phpunit.xml.dist test

PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

....................S...............S...................S.        58 / 58 (100%)

Time: 2.93 minutes, Memory: 16.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 58, Assertions: 123, Skipped: 3.

Generating code coverage report in Clover XML format ... done [116 ms]
➜  firestore git:(fixing_lint) ✗ 
➜  firestore git:(fixing_lint) ✗
```




