### PR TITLE
Download byte range

### DIFF
--- a/storage/src/download_byte_range.php
+++ b/storage/src/download_byte_range.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/storage/src/download_byte_range.php
+++ b/storage/src/download_byte_range.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_download_byte_range]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Download an object from Cloud Storage and save it as a local file.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ * @param string $objectName The name of your Cloud Storage object.
+ * @param string $start_byte The starting byte at which to begin the download.
+ * @param string $end_byte The ending byte at which to end the download.
+ * @param string $destination The local destination to save the object.
+ */
+function download_byte_range($bucketName, $objectName, $start_byte, $end_byte, $destination)
+{
+    // $bucketName = 'my-bucket';
+    // $objectName = 'my-object';
+    // $start_byte = 1;
+    // $end_byte = 5;
+    // $destination = '/path/to/your/file';
+
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $object = $bucket->object($objectName);
+    $object->downloadToFile($destination, [
+        'restOptions' => [
+            'headers' => [
+                'Range' => "bytes=$start_byte-$end_byte",
+            ],
+        ],
+    ]);
+    printf(
+        'Downloaded gs://%s/%s to %s' . PHP_EOL,
+        $bucketName,
+        $objectName,
+        basename($destination)
+    );
+}
+# [END storage_download_byte_range]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);


### PR DESCRIPTION

## Test

`XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectsTest.php --filter=testDownloadByteRange`

```
➜  storage git:(download_byte_range) ✗ XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectsTest.php --filter=testDownloadByteRange
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.28 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist

.                                                                   1 / 1 (100%)

Time: 1.67 seconds, Memory: 10.00 MB

OK (1 test, 5 assertions)

Generating code coverage report in Clover XML format ... done [225 ms]
➜  storage git:(download_byte_range) ✗
```